### PR TITLE
Add configuration options to jdk7 module

### DIFF
--- a/manifests/install7.pp
+++ b/manifests/install7.pp
@@ -23,6 +23,10 @@ define jdk7::install7 (
   $urandom_java_fix            = true,
   $rsa_key_size_fix            = false,  # set true for weblogic 12.1.1 and jdk 1.7 > version 40
   $source_path                 = 'puppet:///modules/jdk7/',
+  $user                        = 'root',
+  $group                       = 'root',
+  $default_links               = true,
+  $install_alternatives        = true,
 ) {
 
   if ( $x64 == true ) {
@@ -36,8 +40,6 @@ define jdk7::install7 (
       $install_version   = 'linux'
       $install_extension = '.tar.gz'
       $path              = '/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:'
-      $user              = 'root'
-      $group             = 'root'
     }
     default: {
       fail("Unrecognized operating system ${::kernel}, please use it on a Linux host")
@@ -99,6 +101,8 @@ define jdk7::install7 (
     alternatives_priority       => $alternatives_priority,
     user                        => $user,
     group                       => $group,
+    default_links               => $default_links,
+    install_alternatives        => $install_alternatives,
     require                     => File["${download_dir}/${jdk_file}"],
   }
 


### PR DESCRIPTION
This module adds the following configuration options.

 - Choose by which uid/gid the Java installation should be owned
 - On/Off switch for links default and latest
 - On/Off switch for the installation of the alternatives

All of this came out of a business requirement we have, as the Java
version is installed within the MWHOME as per our standards which are
based on Oracle's maximum availability architecture and enterprise
deployment guide documents