### PR TITLE
Install jar alternative.

### DIFF
--- a/manifests/config/javaexec.pp
+++ b/manifests/config/javaexec.pp
@@ -130,7 +130,7 @@ define jdk7::config::javaexec (
     }
   }
 
-  $alternatives = [ 'java', 'javac', 'keytool']
+  $alternatives = [ 'jar', 'java', 'javac', 'keytool']
   if ( $install_alternatives ){
     jdk7::config::alternatives{ $alternatives:
       java_home_dir => $java_homes_dir,


### PR DESCRIPTION
The [gerrit module](https://github.com/tykeal/puppet-gerrit) absolutely requires that the "jar" command be in [/usr/bin or /usr/sbin](https://github.com/tykeal/puppet-gerrit/blob/master/manifests/install.pp#L363).