### PR TITLE
Set some resource definitions under condition. Required when multiple install7 resources will be defined

### DIFF
--- a/manifests/config/javaexec.pp
+++ b/manifests/config/javaexec.pp
@@ -109,35 +109,39 @@ define jdk7::config::javaexec (
   }
 
   if ( $default_links ){
-    # java link to latest
-    file { '/usr/java/latest':
-      ensure  => link,
-      target  => $java_dir,
-      require => Exec["extract java ${full_version}"],
-      owner   => $user,
-      group   => $group,
-      mode    => '0755',
-    }
+    if(!defined(File['/usr/java/latest'])) {
+        # java link to latest
+        file { '/usr/java/latest':
+          ensure  => link,
+          target  => $java_dir,
+          require => Exec["extract java ${full_version}"],
+          owner   => $user,
+          group   => $group,
+          mode    => '0755',
+        }
 
-    # java link to default
-    file { '/usr/java/default':
-      ensure  => link,
-      target  => '/usr/java/latest',
-      require => File['/usr/java/latest'],
-      owner   => $user,
-      group   => $group,
-      mode    => '0755',
+        # java link to default
+        file { '/usr/java/default':
+          ensure  => link,
+          target  => '/usr/java/latest',
+          require => File['/usr/java/latest'],
+          owner   => $user,
+          group   => $group,
+          mode    => '0755',
+        }
     }
   }
 
   $alternatives = [ 'jar', 'java', 'javac', 'keytool']
   if ( $install_alternatives ){
-    jdk7::config::alternatives{ $alternatives:
-      java_home_dir => $java_homes_dir,
-      full_version  => $full_version,
-      priority      => $alternatives_priority,
-      user          => $user,
-      group         => $group,
+    if(!defined(Jdk7::Config::Alternatives['java'])) {
+        jdk7::config::alternatives{ $alternatives:
+          java_home_dir => $java_homes_dir,
+          full_version  => $full_version,
+          priority      => $alternatives_priority,
+          user          => $user,
+          group         => $group,
+        }
     }
   }
 }

--- a/manifests/install7.pp
+++ b/manifests/install7.pp
@@ -48,11 +48,13 @@ define jdk7::install7 (
 
   $jdk_file = "jdk-${version}-${install_version}-${type}${install_extension}"
 
-  exec { "create ${download_dir} directory":
-    command => "mkdir -p ${download_dir}",
-    unless  => "test -d ${download_dir}",
-    path    => $path,
-    user    => $user,
+  if !defined(Exec["create ${download_dir} directory"]) {
+    exec { "create ${download_dir} directory":
+        command => "mkdir -p ${download_dir}",
+        unless  => "test -d ${download_dir}",
+        path    => $path,
+        user    => $user,
+    }
   }
 
   # check install folder


### PR DESCRIPTION
Using for example following hiera definitions:
```
java_instances:
    jdk1:
        version: "8u72"
        full_version: "jdk1.8.0_72"
        java_homes: "/opt/java"
        x64: true
        alternatives_priority: 18000
        download_dir: "/var/download"
        source_path: "/var/download"
        urandom_java_fix: true
    jdk2:
        version: "7u95"
        full_version: "jdk1.7.0_95"
        java_homes: "/opt/java"
        x64: true
        alternatives_priority: 18000
        download_dir: "/var/download"
        source_path: "/var/download"
        urandom_java_fix: true
```
