### PR TITLE
Support java_sdk alternative

### DIFF
--- a/manifests/config/alternatives.pp
+++ b/manifests/config/alternatives.pp
@@ -21,12 +21,24 @@ define jdk7::config::alternatives(
     }
   }
 
-  exec { "java alternatives ${title}":
-    command   => "${alt_command} --install /usr/bin/${title} ${title} ${java_home_dir}/${full_version}/bin/${title} ${priority}",
-    unless    => "${alt_command} --display ${title} | /bin/grep ${full_version} | /bin/grep 'priority ${priority}$'",
-    path      => '/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin',
-    logoutput => true,
-    user      => $user,
-    group     => $group,
+  if $title == "java_sdk" {
+    exec { "java alternatives ${title}":
+      command   => "${alt_command} --install /etc/alternatives/{title} ${title} ${java_home_dir}/${full_version} ${priority}",
+      unless    => "${alt_command} --display ${title} | /bin/grep ${full_version} | /bin/grep 'priority ${priority}$'",
+      path      => '/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin',
+      logoutput => true,
+      user      => $user,
+      group     => $group,
+    }
+  }
+  else {
+    exec { "java alternatives ${title}":
+      command   => "${alt_command} --install /usr/bin/${title} ${title} ${java_home_dir}/${full_version}/bin/${title} ${priority}",
+      unless    => "${alt_command} --display ${title} | /bin/grep ${full_version} | /bin/grep 'priority ${priority}$'",
+      path      => '/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin',
+      logoutput => true,
+      user      => $user,
+      group     => $group,
+    }
   }
 }

--- a/manifests/config/javaexec.pp
+++ b/manifests/config/javaexec.pp
@@ -132,7 +132,7 @@ define jdk7::config::javaexec (
     }
   }
 
-  $alternatives = [ 'jar', 'java', 'javac', 'keytool']
+  $alternatives = [ 'jar', 'java', 'javac', 'keytool', 'java_sdk' ]
   if ( $install_alternatives ){
     if(!defined(Jdk7::Config::Alternatives['java'])) {
         jdk7::config::alternatives{ $alternatives:


### PR DESCRIPTION
The `java_sdk` alternative link is a common one.