### PR TITLE
symbolic links not updated during install of new version Java

### DIFF
--- a/manifests/config/alternatives.pp
+++ b/manifests/config/alternatives.pp
@@ -24,7 +24,7 @@ define jdk7::config::alternatives(
   if $title == 'java_sdk' {
     exec { "java alternatives ${title}":
       command   => "${alt_command} --install /etc/alternatives/{title} ${title} ${java_home_dir}/${full_version} ${priority}",
-      unless    => "${alt_command} --display ${title} | /bin/grep ${full_version} | /bin/grep 'priority ${priority}$'",
+      unless    => "${alt_command} --display ${title} | grep -v best  | /bin/grep -v priority | /bin/grep ${full_version}'",
       path      => '/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin',
       logoutput => true,
       user      => $user,
@@ -34,9 +34,10 @@ define jdk7::config::alternatives(
   else {
     exec { "java alternatives ${title}":
       command   => "${alt_command} --install /usr/bin/${title} ${title} ${java_home_dir}/${full_version}/bin/${title} ${priority}",
-      unless    => "${alt_command} --display ${title} | /bin/grep ${full_version} | /bin/grep 'priority ${priority}$'",
+      unless    => "${alt_command} --display ${title} | grep -v best  | /bin/grep -v priority | /bin/grep ${full_version}",
       path      => '/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin',
       logoutput => true,
+	  loglevel  => verbose,
       user      => $user,
       group     => $group,
     }


### PR DESCRIPTION
THe symbolic links in /etc/alternatives are not updated when applying a new version of Java. IMHO the unless check is wrong.