### PR TITLE
Fix title var

### DIFF
--- a/manifests/config/alternatives.pp
+++ b/manifests/config/alternatives.pp
@@ -23,7 +23,7 @@ define jdk7::config::alternatives(
 
   if $title == 'java_sdk' {
     exec { "java alternatives ${title}":
-      command   => "${alt_command} --install /etc/alternatives/{title} ${title} ${java_home_dir}/${full_version} ${priority}",
+      command   => "${alt_command} --install /etc/alternatives/${title} ${title} ${java_home_dir}/${full_version} ${priority}",
       unless    => "${alt_command} --display ${title} | grep -v best  | /bin/grep -v priority | /bin/grep ${full_version}",
       path      => '/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin',
       logoutput => true,


### PR DESCRIPTION
The tiniest of typos here means `/etc/alternatives/{title}` is being passed as the install path instead of `/etc/alternatives/java_sdk`.