### PR TITLE
Enhancement for JCE on 8u151 and higher versions

### DIFF
--- a/manifests/config/javaexec.pp
+++ b/manifests/config/javaexec.pp
@@ -59,7 +59,7 @@ define jdk7::config::javaexec (
     $security_dir = "${java_dir}/jre/lib/security"
     $source_file = "${download_dir}/${cryptography_extension_file}"
     $done_file = "${security_dir}/.jce_installed"
-    $jarfiles = "${security_dir} -mindepth 2 -name '*.jar'"
+    $jarfiles = "${security_dir} -maxdepth 2 -mindepth 2 -name '*.jar'"
     $mv_cmd = "mv '{}' ${security_dir} ';'"
     if ( $cryptography_extension_file =~ /\.zip$/ ) {
       $extract_cmd = 'unzip'

--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,10 @@
   "summary": "Oracle JDK7 & JDK8 puppet module optimized for weblogic urandom rngd entropy",
   "author": "Edwin Biemond",
   "dependencies": [
-
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">=4.9.0"
+    }
   ],
   "source": "https://github.com/biemond/biemond-jdk7",
   "project_page": "https://github.com/biemond/biemond-jdk7",


### PR DESCRIPTION
When the version of java is 8u151 and up to, but not included, 8u161, the JCE policy has changed and now the libraries are included with the tarball. By default it limited and not defined.

For versions starting at 8u161, it is the same as before but by default is set as unlimited. Still not defined in the java.security file.

To allow the module to define and configure this property, the stdlib module has been added as a dependency, to use file_line to add the property to the java.security config file.

As it is limited by versions, there is a check on major and minor version and if the version is not above 8u151, there is a message stating there is no change even if the new parameter has been passed to the class call.

This new parameter is `$crypto_policy` and it is undef by default, with possible values being `unlimited` and `limited`

The changes to `javaexec.pp` are needed as the command used to move the .jar files from the `cryptography_extension_file` also moves the ones in the new version tarball, and as there is a legacy configuration using these `cryptography_extension_file` files, conditioning the use of either `cryptography_extension_file` or `crypto_policy` is ruled out.

